### PR TITLE
Add the ability to leverage a different AWS Profile. Search MCP tool error handling improved.

### DIFF
--- a/src/amazon_datazone_mcp_server/tools/domain_management.py
+++ b/src/amazon_datazone_mcp_server/tools/domain_management.py
@@ -26,6 +26,7 @@ from .common import ClientError, datazone_client, logger
 def register_tools(mcp: FastMCP):
     """Register domain management tools with the MCP server."""
 
+    
     @mcp.tool()
     async def get_domain(identifier: str) -> Any:
         """
@@ -121,7 +122,7 @@ def register_tools(mcp: FastMCP):
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
             if error_code == "AccessDeniedException":
-                logger.error(f"Access denied while creating domain {name}{}")
+                logger.error(f"Access denied while creating domain {name}")
                 raise Exception(f"Access denied while creating domain {name}")
             elif error_code == "ConflictException":
                 logger.error(f"Domain {name} already exists")
@@ -991,7 +992,7 @@ def register_tools(mcp: FastMCP):
             
             if (search_scope == "ASSET" or search_scope == "DATA_PRODUCT") and not owning_project_identifier:
                 raise Exception (
-                    f"To search for this search_scope:{search_scope} the owning_project_identifier is also required. Make sure to provide that as well"
+                    f"To search for this search_scope:{search_scope} the owning_project_identifier is also required. Make sure to provide that as well."
             )
 
             # Prepare the request parameters

--- a/tests/test_domain_management.py
+++ b/tests/test_domain_management.py
@@ -267,7 +267,77 @@ class TestDomainManagement:
 
         # Verify the mock was called correctly
         mcp_server_with_tools._mock_client.search.assert_called_once()
+    @pytest.mark.asyncio
+    async def test_search_success(
+        self, mcp_server_with_tools, tool_extractor, test_data_helper
+    ):
+        """Test successful search operation."""
+        # Configure mock response
+        mcp_server_with_tools._mock_client.search.return_value = {
+            "items": [
+                {
+                    "id": "search_result_123",
+                    "name": "Search Result",
+                    "description": "Test search result",
+                    "assetType": "amazon.datazone.S3Asset",
+                }
+            ],
+            "totalMatchCount": 1,
+        }
 
+        search = tool_extractor(mcp_server_with_tools, "search")
+
+        domain_id = test_data_helper.get_domain_id()
+        search_scope = "ASSET"
+        search_text = "test"
+        owning_project_id = "XXXXXXXXXXX"
+
+        result = await search(
+            domain_identifier=domain_id,
+            search_scope=search_scope,
+            search_text=search_text,
+            owning_project_identifier=owning_project_id,
+        )
+
+        # Verify the result
+        assert result is not None
+        assert "items" in result
+        assert len(result["items"]) == 1
+        assert result["totalMatchCount"] == 1
+
+        # Verify the mock was called correctly
+        mcp_server_with_tools._mock_client.search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_failure(
+        self, mcp_server_with_tools, tool_extractor, test_data_helper
+    ):
+        """Test successful search operation."""
+        # Configure mock response
+        mcp_server_with_tools._mock_client.search.return_value = {
+            "items": [
+                {
+                    "id": "search_result_123",
+                    "name": "Search Result",
+                    "description": "Test search result",
+                    "assetType": "amazon.datazone.S3Asset",
+                }
+            ],
+            "totalMatchCount": 1,
+        }
+
+        search = tool_extractor(mcp_server_with_tools, "search")
+
+        domain_id = test_data_helper.get_domain_id()
+        search_scope = "ASSET"
+        search_text = "test"
+
+        with pytest.raises(Exception):
+            result = await search(
+            domain_identifier=domain_id,
+            search_scope=search_scope,
+            search_text=search_text,
+            )
     @pytest.mark.asyncio
     async def test_add_policy_grant_success(
         self, mcp_server_with_tools, tool_extractor, test_data_helper


### PR DESCRIPTION
*Issue #, if available:* Previously users were not able to use any other AWS profile besides the default profile, and the search mcp tool provided inadequate error reporting.

*Description of changes:*
This code change adds the ability to use a different profile, and revert to the default profile in case that the profile doesn't exist. Additionally the error handling for the search method was improved.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
